### PR TITLE
Fix request_timeout's default/possible values and documentation

### DIFF
--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -64,7 +64,7 @@ Monitor lookup.
 - **recovery_period** (Number) How long the monitor must be up to automatically mark an incident as resolved after being down.
 - **regions** (List of String) An array of regions to set. Allowed values are ["us", "eu", "as", "au"] or any subset of these regions.
 - **request_body** (String) Request body for POST, PUT, PATCH requests.
-- **request_timeout** (Number) How long to wait before timing out the request? In seconds.
+- **request_timeout** (Number) How long to wait before timing out the request? In milliseconds. Valid values are 5000, 3000, 2000, 1000 and 500.
 - **required_keyword** (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.
 - **sms** (Boolean) Should we send an SMS to the on-call person?
 - **ssl_expiration** (Number) How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -63,7 +63,7 @@ https://docs.betteruptime.com/api/monitors-api
 - **recovery_period** (Number) How long the monitor must be up to automatically mark an incident as resolved after being down.
 - **regions** (List of String) An array of regions to set. Allowed values are ["us", "eu", "as", "au"] or any subset of these regions.
 - **request_body** (String) Request body for POST, PUT, PATCH requests.
-- **request_timeout** (Number) How long to wait before timing out the request? In seconds.
+- **request_timeout** (Number) How long to wait before timing out the request? In milliseconds. Valid values are 5000, 3000, 2000, 1000 and 500.
 - **required_keyword** (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.
 - **sms** (Boolean) Should we send an SMS to the on-call person?
 - **ssl_expiration** (Number) How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.

--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -180,10 +180,12 @@ var monitorSchema = map[string]*schema.Schema{
 		// TODO: ValidateDiagFunc: validation.StringInSlice
 	},
 	"request_timeout": {
-		Description: "How long to wait before timing out the request? In seconds.",
+		Description: "How long to wait before timing out the request? In milliseconds." +
+			" Valid values are 5000, 3000, 2000, 1000 and 500.",
 		Type:        schema.TypeInt,
 		Optional:    true,
-		Default:     30,
+		Default:     5000,
+		// TODO: ValidateDiagFunc: validation.IntInSlice
 	},
 	"request_body": {
 		Description: "Request body for POST, PUT, PATCH requests.",


### PR DESCRIPTION
Fixes default value, possible values and documentation for `request_timeout` which was causing unprompted change:

```hcl
# betteruptime_monitor.test will be updated in-place
~ resource "betteruptime_monitor" "test" {
      id                  = "123456"
    ~ request_timeout     = 5000 -> 30
      # (17 unchanged attributes hidden)
  }
```

And error:

```
╷
│ Error: PATCH https://betteruptime.com/api/v2/monitors/123456 returned 422: {"errors":{"base":["Request timeout is invalid. Valid values are: [5000, 3000, 2000, 1000, 500]"]}}│
│   with betteruptime_monitor.test,
│   on test.tf line 1, in resource "betteruptime_monitor" "test":
│   1: resource "betteruptime_monitor" "test" {
│
```