### PR TITLE
Fix region diff suppression for undefined regions

### DIFF
--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -131,6 +131,9 @@ var monitorSchema = map[string]*schema.Schema{
 			Type: schema.TypeString,
 		},
 		Optional: true,
+		DiffSuppressFunc: func(k, old, new []string, d *schema.ResourceData) bool {
+			return len(old) == 0 || reflect.DeepEqual(old, new)
+		},
 		// TODO: ValidateDiagFunc
 	},
 	"monitor_group_id": {


### PR DESCRIPTION
This is an attempt to fix region diff suppression when regions are not manually defined in code:

```
# betteruptime_monitor.test will be updated in-place
~ resource "betteruptime_monitor" "test" {
      id                  = "123456"
    ~ regions             = [
        - "us",
        - "eu",
        - "as",
        - "au",
      ]
      # (17 unchanged attributes hidden)
  }
```

With this resource:

```hcl
resource "betteruptime_monitor" "test" {
  monitor_type = "status"
  url          = "https://google.com/"
}
```

As I'm not a Go/TF developer, please review this PR carefully.